### PR TITLE
Version 0.2.0-SNAPSHOT

### DIFF
--- a/common-tests/pom.xml
+++ b/common-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.brooklyn.common</groupId>
     <artifactId>common-catalog-utils-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version> <!-- COMMON_CATALOG_UTILS_VERSION -->
+    <version>0.2.0-SNAPSHOT</version> <!-- COMMON_CATALOG_UTILS_VERSION -->
   </parent>
 
   <name>Common Test Catalog Utils</name>

--- a/common-tests/src/main/resources/commontests/common.tests.bom
+++ b/common-tests/src/main/resources/commontests/common.tests.bom
@@ -18,7 +18,7 @@
  ##
 
 brooklyn.catalog:
-  version: "0.1.0-SNAPSHOT" # COMMON_CATALOG_UTILS_VERSION
+  version: "0.2.0-SNAPSHOT" # COMMON_CATALOG_UTILS_VERSION
   license_code: APACHE-2.0
 
   items:

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.brooklyn.common</groupId>
     <artifactId>common-catalog-utils-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version> <!-- COMMON_CATALOG_UTILS_VERSION -->
+    <version>0.2.0-SNAPSHOT</version> <!-- COMMON_CATALOG_UTILS_VERSION -->
   </parent>
 
   <name>Common Catalog Utils</name>

--- a/common/src/main/resources/common/common.bom
+++ b/common/src/main/resources/common/common.bom
@@ -6,7 +6,7 @@
  ##
 
 brooklyn.catalog:
-  version: "0.1.0-SNAPSHOT" # COMMON_CATALOG_UTILS_VERSION
+  version: "0.2.0-SNAPSHOT" # COMMON_CATALOG_UTILS_VERSION
   license_code: APACHE-2.0
   publish:
     description: |

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.brooklyn.common</groupId>
     <artifactId>common-catalog-utils-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.0-SNAPSHOT</version> <!-- COMMON_CATALOG_UTILS_VERSION -->
+    <version>0.2.0-SNAPSHOT</version> <!-- COMMON_CATALOG_UTILS_VERSION -->
 
     <name>Common Catalog Utils</name>
     <description>Apache Brooklyn catalog items, to make writing blueprints and tests simpler</description>


### PR DESCRIPTION
Updates the version of the BOM files to _0.2.0-SNAPSHOT_.

I am creating this PR because some other external catalog files link to the raw files from the `master` branch, so I want to be sure this will not affect anything before merging. Note that anything linking to files in `master` should be changes to use the _0.1.0_ release resources:

- https://github.com/brooklyncentral/common-catalog-utils/releases/tag/v0.1.0
- https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.bom
- https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.tests.bom